### PR TITLE
CI: Only run on pull requests

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,9 +1,6 @@
 name: build IPDK site
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Since GitHub automaticaly deploys on merges for us, this job should only
run on pull requests.

Signed-off-by: Kyle Mestery <mestery@mestery.com>